### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        ruby: ['3.0', 2.7, 2.6, jruby-9.1.17.0, truffleruby]
+        ruby: ['3.0', 2.7, 2.6, jruby-9.3.15.0, truffleruby]
         gemfile:
           [
             norails,
@@ -72,11 +72,11 @@ jobs:
           gemfile: rails_4.2_mongoid_5
         - ruby: 2.6
           gemfile: rails_4.2
-        - ruby: jruby-9.1.17.0
+        - ruby: jruby-9.3.15.0
           gemfile: norails
-        - ruby: jruby-9.1.17.0
+        - ruby: jruby-9.3.15.0
           gemfile: rails_5.2
-        - ruby: jruby-9.1.17.0
+        - ruby: jruby-9.3.15.0
           gemfile: rails_6.1
         - ruby: truffleruby
           gemfile: rails_4.2

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -124,7 +124,7 @@ if defined?(ActiveRecord)
 
           it "should raise an error for transitions" do
             if ActiveRecord.gem_version >= Gem::Version.new('7.1.0')
-              expect{multiple_with_enum_without_column.send(:view, :left)}.to raise_error(RuntimeError, /Unknown enum attribute 'status'/)
+              expect{multiple_with_enum_without_column.send(:view, :left)}.to raise_error(RuntimeError, /Undeclared attribute type for enum 'status'/)
             else
               expect{multiple_with_enum_without_column.send(:view, :left)}.to raise_error(NoMethodError, /undefined method .status./)
             end

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -124,7 +124,7 @@ if defined?(ActiveRecord)
 
           it "should raise an error for transitions" do
             if ActiveRecord.gem_version >= Gem::Version.new('7.1.0')
-              expect{with_enum_without_column.send(:view)}.to raise_error(RuntimeError, /Unknown enum attribute 'status'/)
+              expect{with_enum_without_column.send(:view)}.to raise_error(RuntimeError, /Undeclared attribute type for enum 'status'/)
             else
               expect{with_enum_without_column.send(:view)}.to raise_error(NoMethodError, /undefined method .status./)
             end


### PR DESCRIPTION
The behavior of non-column-backed attributes for `enum` was changed by https://github.com/rails/rails/pull/49769.